### PR TITLE
Add PAD and UNK to words list after the word2ind and ind2word is populated

### DIFF
--- a/dan/dan.py
+++ b/dan/dan.py
@@ -37,8 +37,6 @@ def load_words(exs):
     words = set()
     UNK = '<unk>'
     PAD = '<pad>'
-    words.add(PAD)
-    words.add(UNK)
     word2ind = {PAD: 0, UNK: 1}
     ind2word = {0: PAD, 1: UNK}
     for q_text, _ in exs:
@@ -49,6 +47,7 @@ def load_words(exs):
         idx = len(word2ind)
         word2ind[w] = idx
         ind2word[idx] = w
+    words = [PAD, UNK] + words
     return words, word2ind, ind2word
 
 


### PR DESCRIPTION
We already add manual entries to word2ind and ind2word for PAD and UNK.
Hence having PAD and UNK in words list before populating dicts does not yield intended values.